### PR TITLE
Remove `silverstripe/cms` as a requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,13 @@
         "php": "~8.0",
         "silverstripe/framework": "~5.0",
         "phpstan/phpstan": "^1.5",
-        "silverstripe/versioned": "^2.0",
-        "silverstripe/cms": "^5.0"
+        "silverstripe/versioned": "^2.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.0",
         "phpstan/phpstan-phpunit": "^1",
-        "phpunit/phpunit": "^9.4"
+        "phpunit/phpunit": "^9.4",
+        "silverstripe/cms": "^5.0"
     },
     "scripts": {
         "phpcs": "phpcs -n -l src/ src/Reflection/ src/Rule/ src/Type tests/ tests/Reflection/ tests/Rule/ tests/Type/",

--- a/stubs/Page.php
+++ b/stubs/Page.php
@@ -4,5 +4,9 @@ namespace {
 
     use SilverStripe\CMS\Model\SiteTree;
 
+    if (!class_exists(SilverStripe\CMS\Model\SiteTree::class)) {
+        return;
+    }
+
     class Page extends SiteTree {}
 }

--- a/stubs/PageController.php
+++ b/stubs/PageController.php
@@ -4,5 +4,9 @@ namespace {
 
     use SilverStripe\CMS\Controllers\ContentController;
 
+    if (!class_exists(SilverStripe\CMS\Controllers\ContentController::class)) {
+        return;
+    }
+
     class PageController extends ContentController {}
 }


### PR DESCRIPTION
## Description

- Remove `silverstripe/cms` as a requirement. This was done to make it easier to use this module with other silverstripe modules. Not all modules are reliant on `silverstripe/cms`.
- Add `silverstripe/cms` as a dev requirement so we can still pass the tests

## Resolves

- #29 
