### PR TITLE
fix: QUICKFIX: remove `ReadWriteConfigPropertiesRule` as it triggers an error

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -83,14 +83,15 @@ services:
         tags:
             - phpstan.typeSpecifier.methodTypeSpecifyingExtension
     # Rule informing the user to add the @config docblock
-    -
-        class: Syntro\SilverstripePHPStan\Rule\ReadWriteConfigPropertiesRule
-        arguments:
-            alwaysWrittenTags: %propertyAlwaysWrittenTags%
-            alwaysReadTags: %propertyAlwaysReadTags%
-            checkUninitializedProperties: %checkUninitializedProperties%
-        tags:
-            - phpstan.rules.rule
+    # TODO (mleutenegger, 18.9.25): find a way to get this done properly
+    # -
+    #     class: Syntro\SilverstripePHPStan\Rule\ReadWriteConfigPropertiesRule
+    #     arguments:
+    #         alwaysWrittenTags: %propertyAlwaysWrittenTags%
+    #         alwaysReadTags: %propertyAlwaysReadTags%
+    #         checkUninitializedProperties: %checkUninitializedProperties%
+    #     tags:
+    #         - phpstan.rules.rule
     # Special handling for configuration properties
     -
         class: Syntro\SilverstripePHPStan\Reflection\ReadWritePropertiesExtension


### PR DESCRIPTION

Comment out ReadWriteConfigPropertiesRule configuration for future implementation.